### PR TITLE
Fix SeqParallelLiteAttention not forwarding config param

### DIFF
--- a/hopper/lite_attention.py
+++ b/hopper/lite_attention.py
@@ -1396,6 +1396,7 @@ class SeqParallelLiteAttention:
                 threshold=threshold,
                 max_batch_size=max_batch_size,
                 use_int8=use_int8,
+                config=config,
             )
             for _ in range(num_nodes)
         ]


### PR DESCRIPTION
## Summary
- `SeqParallelLiteAttention.__init__` accepted a `config` parameter but never passed it to the `LiteAttention` instances it creates, silently ignoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)