### PR TITLE
Add reverse skip list support to AMD kernel

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,6 +47,8 @@ jobs:
               match = re.match(r"(\d+)\.(\d+)", cuda_version)
               if match:
                   major, minor = match.groups()
+                  if major == "13":
+                      minor = "0" # no wheel for CUDA 13.1 yet
                   torch_label = f"cu{major}{minor}"
 
           index_url = f"https://download.pytorch.org/whl/{torch_label}" if torch_label else "https://download.pytorch.org/whl/cpu"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,7 +63,7 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install packaging wheel ninja
-          python -m pip install --extra-index-url "${TORCH_INDEX_URL}" torch
+          python -m pip install torch --index-url "${TORCH_INDEX_URL}"
           python -m pip install numpy
 
       - name: Clean and install project with dev extras

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -82,6 +82,8 @@ jobs:
           python -c "import torch; print(f'torch=={torch.__version__}')" > /tmp/torch-pin.txt
           echo "Pinning: $(cat /tmp/torch-pin.txt)"
           echo "CUDA_HOME=$CUDA_HOME"
+          export CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
+          echo "CUDA_HOME=$CUDA_HOME"
           LITE_ATTENTION_FORCE_CXX11_ABI=$CXX11_ABI \
             pip install --no-build-isolation \
               --extra-index-url "${TORCH_INDEX_URL}" \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -74,7 +74,15 @@ jobs:
           # Match PyTorch C++ ABI to avoid undefined symbol (c10::* or ListType::get)
           CXX11_ABI=$(python -c "import torch; print('TRUE' if torch._C._GLIBCXX_USE_CXX11_ABI else 'FALSE')")
           echo "Building with LITE_ATTENTION_FORCE_CXX11_ABI=$CXX11_ABI"
-          LITE_ATTENTION_FORCE_CXX11_ABI=$CXX11_ABI python -m pip install --no-build-isolation .[dev]
+          # Pin torch to the CUDA-matched version installed earlier so pip
+          # doesn't replace it with a PyPI wheel built for a different CUDA.
+          python -c "import torch; print(f'torch=={torch.__version__}')" > /tmp/torch-pin.txt
+          echo "Pinning: $(cat /tmp/torch-pin.txt)"
+          LITE_ATTENTION_FORCE_CXX11_ABI=$CXX11_ABI \
+            pip install --no-build-isolation \
+              --extra-index-url "${TORCH_INDEX_URL}" \
+              -c /tmp/torch-pin.txt \
+              .[dev]
 
       - name: Run pytest tests
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,13 +34,24 @@ jobs:
           import subprocess
 
           cuda_version = None
+          # Use nvcc (actual toolkit) rather than nvidia-smi (driver max CUDA).
+          # PyTorch's _check_cuda_version compares nvcc against torch.version.cuda.
           try:
-              output = subprocess.check_output(["nvidia-smi"], text=True)
-              match = re.search(r"CUDA Version:\s*([0-9.]+)", output)
+              output = subprocess.check_output(["nvcc", "--version"], text=True)
+              match = re.search(r"release (\d+\.\d+)", output)
               if match:
                   cuda_version = match.group(1)
-          except Exception as exc:  # noqa: BLE001
-              print(f"Could not detect CUDA version: {exc}")
+          except Exception:  # noqa: BLE001
+              pass
+
+          if not cuda_version:
+              try:
+                  output = subprocess.check_output(["nvidia-smi"], text=True)
+                  match = re.search(r"CUDA Version:\s*([0-9.]+)", output)
+                  if match:
+                      cuda_version = match.group(1)
+              except Exception as exc:  # noqa: BLE001
+                  print(f"Could not detect CUDA version: {exc}")
 
           torch_label = None
           if cuda_version:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,6 +81,7 @@ jobs:
           # doesn't replace it with a PyPI wheel built for a different CUDA.
           python -c "import torch; print(f'torch=={torch.__version__}')" > /tmp/torch-pin.txt
           echo "Pinning: $(cat /tmp/torch-pin.txt)"
+          echo "CUDA_HOME=$CUDA_HOME"
           LITE_ATTENTION_FORCE_CXX11_ABI=$CXX11_ABI \
             pip install --no-build-isolation \
               --extra-index-url "${TORCH_INDEX_URL}" \

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,24 +34,14 @@ jobs:
           import subprocess
 
           cuda_version = None
-          # Use nvcc (actual toolkit) rather than nvidia-smi (driver max CUDA).
-          # PyTorch's _check_cuda_version compares nvcc against torch.version.cuda.
+          # nvcc reports the toolkit PyTorch compares against in _check_cuda_version.
           try:
               output = subprocess.check_output(["nvcc", "--version"], text=True)
               match = re.search(r"release (\d+\.\d+)", output)
               if match:
                   cuda_version = match.group(1)
-          except Exception:  # noqa: BLE001
-              pass
-
-          if not cuda_version:
-              try:
-                  output = subprocess.check_output(["nvidia-smi"], text=True)
-                  match = re.search(r"CUDA Version:\s*([0-9.]+)", output)
-                  if match:
-                      cuda_version = match.group(1)
-              except Exception as exc:  # noqa: BLE001
-                  print(f"Could not detect CUDA version: {exc}")
+          except Exception as exc:  # noqa: BLE001
+              print(f"Could not run nvcc --version: {exc}")
 
           torch_label = None
           if cuda_version:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "csrc/composable_kernel"]
 	path = csrc/composable_kernel
 	url = https://github.com/moonmath-ai/composable_kernel.git
-	branch = idan/add_la_support
+	branch = feat/conv_fp8

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "csrc/composable_kernel"]
 	path = csrc/composable_kernel
 	url = https://github.com/moonmath-ai/composable_kernel.git
-	branch = feat/conv_fp8
+	branch = feat/lite_attention

--- a/README.md
+++ b/README.md
@@ -357,16 +357,15 @@ LiteAttention on **AMD (ROCm)** uses the Composable Kernel (CK) backend and does
 
 | Feature | NVIDIA (CUDA) | AMD (ROCm) |
 |--------|----------------|------------|
-| **dtypes** | fp16, bf16; optionally fp8, int8 (build flags) | fp16, bf16 only |
-| **head_dim** | 64, 96, 128, 192, 256 (depending on build) | 64, 96, 128, 192, 256 |
+| **dtypes** | fp16, bf16; optionally fp8, int8 (build flags) | bf16 only |
+| **head_dim** | 64, 96, 128, 192, 256 (depending on build) | 64, 96, 128, 192 |
 | **Skip lists** (read/write, threshold, reverse_skip_list) | ✅ | ✅ |
-| **must_do_list** | ✅ | ❌ Not in HIP API; argument is ignored |
-| **phase** (for reverse_skip_list) | ✅ | ❌ Not passed to HIP kernel |
-| **return_softmax_lse** | ✅ | ⚠️ With skip lists, LSE is not computed by the lite kernel; returned tensor may be undefined |
-| **Dropout** | Supported in API | Passed as 0 in Python; not used |
-| **Varlen / KV-cache / paged KV** | Available in full FA3 API | Only batch fwd used; varlen/kvcache not wired in Python for ROCm |
+| **Phase alternation** (forward/reverse iteration) | ✅ | ✅ |
+| **must_do_list** | ✅ | ❌ Not supported by CK kernel |
+| **return_softmax_lse** | ✅ | ❌ Lite kernel does not compute LSE |
+| **Varlen / KV-cache / paged KV** | Available in full FA3 API | ❌ Batch forward only |
 
-When writing code that runs on both backends, avoid relying on `must_do_list`, and use `return_softmax_lse=True` only when not using skip lists (or only on CUDA).
+When writing code that runs on both backends, avoid relying on `must_do_list` and `return_softmax_lse`.
 
 ---
 

--- a/csrc/lite_attn_ck/lite_attn.hip
+++ b/csrc/lite_attn_ck/lite_attn.hip
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026, LiteAttention contributors.
+//
+// Minimal CK fmha_fwd wrapper for LiteAttention on AMD MI300X.
+// Only supports: batch mode, bf16, no bias/alibi/dropout/fp8/varlen/kvcache.
+
+#include <torch/extension.h>
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+
+#include "fmha_fwd.hpp"
+#include "mask.hpp"
+
+// ---------------------------------------------------------------------------
+// lite_attn_fwd — the only entry point
+// ---------------------------------------------------------------------------
+std::vector<at::Tensor>
+lite_attn_fwd(at::Tensor q,         // [B, S_q, H_q, D]
+              at::Tensor k,         // [B, S_k, H_k, D]
+              at::Tensor v,         // [B, S_k, H_k, D]
+              float softmax_scale,
+              bool is_causal,
+              std::optional<at::Tensor> skip_read,      // [B, H, qt, kt+2] int16
+              std::optional<at::Tensor> skip_write,     // [B, H, qt, kt+2] int16
+              float skip_threshold,
+              bool reverse_skip_list,
+              bool phase)
+{
+    // --- basic checks ---
+    TORCH_CHECK(q.dtype() == at::ScalarType::BFloat16, "q must be bf16");
+    TORCH_CHECK(k.dtype() == at::ScalarType::BFloat16, "k must be bf16");
+    TORCH_CHECK(v.dtype() == at::ScalarType::BFloat16, "v must be bf16");
+    TORCH_CHECK(q.stride(-1) == 1, "q must have contiguous last dim");
+    TORCH_CHECK(k.stride(-1) == 1, "k must have contiguous last dim");
+    TORCH_CHECK(v.stride(-1) == 1, "v must have contiguous last dim");
+
+    const int B      = q.size(0);
+    const int S_q    = q.size(1);
+    const int H_q    = q.size(2);
+    const int D      = q.size(3);
+    const int S_k    = k.size(1);
+    const int H_k    = k.size(2);
+
+    TORCH_CHECK(B > 0, "batch size must be positive");
+    TORCH_CHECK(D <= 192, "head dim must be <= 192 (CK lite kernel supports 64, 96, 128, 192)");
+    TORCH_CHECK(D % 8 == 0, "head dim must be a multiple of 8");
+    TORCH_CHECK(H_q % H_k == 0, "H_q must be divisible by H_k");
+
+    bool is_lite = skip_read.has_value() && skip_read.value().numel() > 0;
+
+    // --- allocate output + lse ---
+    auto opts = q.options();
+    at::Tensor out = torch::empty({B, S_q, H_q, D}, opts);
+    at::Tensor softmax_lse =
+        is_lite ? torch::empty({0}, opts.dtype(torch::kFloat32))
+                : torch::empty({B, H_q, S_q}, opts.dtype(torch::kFloat32));
+
+    const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard{q.device()};
+
+    if (S_k == 0) {
+        out.zero_();
+        if (!is_lite) {
+            softmax_lse.fill_(std::numeric_limits<float>::infinity());
+        }
+        return {out, softmax_lse};
+    }
+
+    // --- mask ---
+    mask_info mask;
+    if (is_causal) {
+        std::string mask_id = "b:-1,0,0";
+        mask = mask_info::decode(mask_id, S_q, S_k);
+    } else {
+        mask = mask_info::decode("0", S_q, S_k);
+    }
+
+    // --- build fmha_fwd_traits (runtime dispatch key) ---
+    fmha_fwd_traits traits{
+        /*hdim_q=*/D,
+        /*hdim_v=*/D,
+        /*data_type=*/std::string("bf16"),
+        /*is_group_mode=*/false,
+        /*is_v_rowmajor=*/true,
+        /*has_logits_soft_cap=*/false,
+        /*mask_type=*/mask.type,
+        /*bias_type=*/bias_enum::no_bias,
+        /*has_lse=*/!is_lite,  // lite pipeline doesn't support LSE output
+        /*has_dropout=*/false,
+        /*qscale_type=*/quant_scale_enum::no_scale,
+        /*skip_min_seqlen_q=*/false,
+        /*has_sink=*/false,
+        /*is_lite=*/is_lite,
+    };
+
+    // --- build fmha_fwd_args ---
+    // Dummy drop_seed_offset (no dropout)
+    auto drop_seed_offset = std::pair<uint64_t, uint64_t>{0, 0};
+
+    fmha_fwd_args args{
+        /*q_ptr=*/q.data_ptr(),
+        /*k_ptr=*/k.data_ptr(),
+        /*v_ptr=*/v.data_ptr(),
+        /*bias_ptr=*/nullptr,
+        /*q_descale_ptr=*/nullptr,
+        /*k_descale_ptr=*/nullptr,
+        /*v_descale_ptr=*/nullptr,
+        /*rand_val_ptr=*/nullptr,
+        /*lse_ptr=*/is_lite ? nullptr : softmax_lse.data_ptr(),
+        /*o_ptr=*/out.data_ptr(),
+        /*seqstart_q_ptr=*/nullptr,
+        /*seqstart_k_ptr=*/nullptr,
+        /*seqlen_q_ptr=*/nullptr,
+        /*seqlen_k_ptr=*/nullptr,
+        /*cu_seqlen_q_ptr=*/nullptr,
+        /*cu_seqlen_k_ptr=*/nullptr,
+        /*block_scale_seqstart_q_ptr=*/nullptr,
+        /*block_scale_seqstart_k_ptr=*/nullptr,
+        /*seqstart_v_scale_ptr=*/nullptr,
+        /*sink_ptr=*/nullptr,
+        /*seqlen_q=*/S_q,
+        /*seqlen_k=*/S_k,
+        /*batch=*/B,
+        /*max_seqlen_q=*/S_q,
+        /*hdim_q=*/D,
+        /*hdim_v=*/D,
+        /*nhead_q=*/H_q,
+        /*nhead_k=*/H_k,
+        /*scale_s=*/softmax_scale,
+        /*logits_soft_cap=*/0.0f,
+        // strides: q/k/v/o are [B, S, H, D] contiguous-last-dim
+        /*stride_q=*/q.stride(1),
+        /*stride_k=*/k.stride(1),
+        /*stride_v=*/v.stride(1),
+        /*stride_bias=*/0,
+        /*stride_randval=*/0,
+        /*stride_o=*/out.stride(1),
+        /*stride_q_descale=*/0,
+        /*stride_k_descale=*/0,
+        /*stride_v_descale=*/0,
+        /*nhead_stride_q=*/q.stride(2),
+        /*nhead_stride_k=*/k.stride(2),
+        /*nhead_stride_v=*/v.stride(2),
+        /*nhead_stride_bias=*/0,
+        /*nhead_stride_randval=*/0,
+        /*nhead_stride_lse=*/is_lite ? 0 : softmax_lse.stride(1),
+        /*nhead_stride_o=*/out.stride(2),
+        /*nhead_stride_q_descale=*/0,
+        /*nhead_stride_k_descale=*/0,
+        /*nhead_stride_v_descale=*/0,
+        /*batch_stride_q=*/q.stride(0),
+        /*batch_stride_k=*/k.stride(0),
+        /*batch_stride_v=*/v.stride(0),
+        /*batch_stride_bias=*/0,
+        /*batch_stride_randval=*/0,
+        /*batch_stride_lse=*/is_lite ? 0 : softmax_lse.stride(0),
+        /*batch_stride_o=*/out.stride(0),
+        /*batch_stride_q_descale=*/0,
+        /*batch_stride_k_descale=*/0,
+        /*batch_stride_v_descale=*/0,
+        /*window_size_left=*/mask.left,
+        /*window_size_right=*/mask.right,
+        /*sink_size=*/mask.sink,
+        /*mask_type=*/static_cast<ck_tile::index_t>(mask.type),
+        /*min_seqlen_q=*/0,
+        /*p_drop=*/0.0f,
+        /*s_randval=*/false,
+        /*drop_seed_offset=*/drop_seed_offset,
+        /*block_scale_size_q=*/128,
+        /*block_scale_size_kv=*/128,
+    };
+
+    // --- skip list strides (from 4D [B, H, qt, kt+2] tensor) ---
+    args.attn_read_list_ptr = skip_read.has_value()
+        ? static_cast<const void*>(skip_read.value().data_ptr<int16_t>())
+        : nullptr;
+    args.attn_write_list_ptr = skip_write.has_value()
+        ? static_cast<void*>(skip_write.value().data_ptr<int16_t>())
+        : nullptr;
+    if (is_lite) {
+        const auto& sl = skip_read.value();
+        args.attn_list_stride_q = static_cast<ck_tile::index_t>(sl.stride(2));
+        args.attn_list_stride_h = static_cast<ck_tile::index_t>(sl.stride(1));
+        args.attn_list_stride_b = static_cast<ck_tile::index_t>(sl.stride(0));
+    } else {
+        args.attn_list_stride_q = 0;
+        args.attn_list_stride_h = 0;
+        args.attn_list_stride_b = 0;
+    }
+    args.threshold = skip_threshold;
+    args.reverse_skip_list = reverse_skip_list && phase;
+
+    // --- launch ---
+    auto stream = at::hip::getCurrentHIPStream();
+    ck_tile::stream_config stream_config{stream};
+
+    float t = fmha_fwd(traits, args, stream_config);
+    TORCH_CHECK(t >= 0, "fmha_fwd dispatch failed (no matching kernel)");
+
+    return {out, softmax_lse};
+}
+
+// ---------------------------------------------------------------------------
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("lite_attn_fwd", &lite_attn_fwd,
+          "LiteAttention forward (CK fmha with skip lists)",
+          py::arg("q"),
+          py::arg("k"),
+          py::arg("v"),
+          py::arg("softmax_scale"),
+          py::arg("is_causal"),
+          py::arg("skip_read") = py::none(),
+          py::arg("skip_write") = py::none(),
+          py::arg("skip_threshold") = -1e30f,
+          py::arg("reverse_skip_list") = false,
+          py::arg("phase") = false);
+}

--- a/hopper/_internal/flash_attn_interface.py
+++ b/hopper/_internal/flash_attn_interface.py
@@ -94,26 +94,17 @@ def _flash_attn_forward(
         hasattr(flash_attn_3_cuda, "__name__")
         and flash_attn_3_cuda.__name__ == "flash_attn_2_cuda"
     ):
-        out, softmax_lse, *rest = flash_attn_3_cuda.fwd(
-            q=q,
-            k=k,
-            v=v,
-            out_=out,
-            alibi_slopes_=None,
-            p_dropout=0.0,
-            softmax_scale=softmax_scale,
+        out, softmax_lse = flash_attn_3_cuda.lite_attn_fwd(
+            q.contiguous(), k.contiguous(), v.contiguous(),
+            softmax_scale=softmax_scale if softmax_scale is not None else q.shape[-1] ** -0.5,
             is_causal=causal,
-            window_size_left=window_size[0],
-            window_size_right=window_size[1],
-            softcap=softcap,
-            return_softmax=return_softmax_lse,
-            gen_=None,
-            attn_read_list=attn_read_list,
-            attn_write_list=attn_write_list,
-            threshold=thr,
+            skip_read=attn_read_list,
+            skip_write=attn_write_list,
+            skip_threshold=thr,
             reverse_skip_list=reverse_skip_list,
+            phase=phase,
         )
-        return out, softmax_lse, *rest
+        return out, softmax_lse
     out, softmax_lse, *rest = flash_attn_3_cuda.fwd(
         q,
         k,

--- a/hopper/_internal/flash_attn_interface.py
+++ b/hopper/_internal/flash_attn_interface.py
@@ -3,7 +3,6 @@
 from typing import Optional, Union
 
 import torch
-import torch.nn as nn
 
 # isort: off
 # We need to import the CUDA kernels after importing torch
@@ -18,7 +17,7 @@ try:
         flash_attn_3_cuda = _C
     else:
         flash_attn_3_cuda = torch.ops.lite_attention
-except ImportError as e:
+except ImportError:
     # Fallback: check if _C is already available in lite_attention module (e.g. injected by test script)
     import sys
 
@@ -95,8 +94,12 @@ def _flash_attn_forward(
         and flash_attn_3_cuda.__name__ == "flash_attn_2_cuda"
     ):
         out, softmax_lse = flash_attn_3_cuda.lite_attn_fwd(
-            q.contiguous(), k.contiguous(), v.contiguous(),
-            softmax_scale=softmax_scale if softmax_scale is not None else q.shape[-1] ** -0.5,
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            softmax_scale=softmax_scale
+            if softmax_scale is not None
+            else q.shape[-1] ** -0.5,
             is_causal=causal,
             skip_read=attn_read_list,
             skip_write=attn_write_list,

--- a/hopper/calibrated_module/module.py
+++ b/hopper/calibrated_module/module.py
@@ -4,7 +4,6 @@ ConfigurableModule mixin: adds config and calibration support to nn.Module.
 
 from __future__ import annotations
 
-import typing
 import warnings
 
 import structlog

--- a/hopper/lite_attention.py
+++ b/hopper/lite_attention.py
@@ -115,35 +115,6 @@ else:
 log = structlog.get_logger()
 
 
-def _rocm_lse_fp32_chunked(
-    q: torch.Tensor, k: torch.Tensor, softmax_scale: float, chunk_size: int = 128
-) -> torch.Tensor:
-    """Compute LSE in fp32 with chunked K iteration to avoid OOM on long sequences.
-
-    Used as a precision fallback on ROCm for non-power-of-2 head dimensions where the CK
-    kernel accumulates bf16 rounding error.  The chunked log-sum-exp formula is:
-        LSE(q, k_full) = log( sum_chunks exp(LSE_chunk) )
-                       = logaddexp over all chunks of LSE_chunk
-    """
-    # q: [batch, q_len, heads, head_dim]
-    q_t = q.float().permute(0, 2, 1, 3)  # [B, H, Lq, D]
-    k_t = k.float().permute(0, 2, 1, 3)  # [B, H, Lk, D]
-    k_len = k_t.shape[2]
-
-    lse: Optional[torch.Tensor] = None
-    for ki in range(0, k_len, chunk_size):
-        k_chunk = k_t[:, :, ki : ki + chunk_size, :]
-        scores = (
-            torch.matmul(q_t, k_chunk.transpose(-1, -2)) * softmax_scale
-        )  # [B, H, Lq, kchunk]
-        chunk_lse = torch.logsumexp(scores, dim=-1)  # [B, H, Lq]
-        if lse is None:
-            lse = chunk_lse
-        else:
-            lse = torch.logaddexp(lse, chunk_lse)
-
-    return lse  # [B, H, Lq]
-
 
 @dataclass
 class LiteAttentionRunConfig(CalibratedRunConfig):
@@ -257,9 +228,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
         # Statistics
         self._last_percentage = 0.0  # Percentage of tiles computed in last pass
         self._last_use_int8 = use_int8  # Whether using int8 quantization in last pass
-        # ROCm: extra warmup passes needed after skip list initialization to ensure
-        # the skip list converges before the user's 2 standard warmup passes
-        self._rocm_needs_extra_warmup = False
 
         # Public configuration
         self.enable_skipping = enable_skipping
@@ -406,6 +374,9 @@ class LiteAttention(nn.Module, ConfigurableModule):
                 - kBlockM: Number of rows per tile (query dimension)
                 - kBlockN: Number of columns per tile (key dimension)
         """
+        if _IS_ROCM:
+            # CK kernel uses fixed tile sizes: 128x128, except 128x64 for D<=64
+            return 128, (64 if head_dim <= 64 else 128)
         is_int8 = dtype == torch.int8
         element_size = dtype.itemsize
         # Call C++ tile_size_fwd_sm90 function
@@ -531,15 +502,9 @@ class LiteAttention(nn.Module, ConfigurableModule):
             )
         else:
             # Initialize first buffer with "compute all tiles" configuration.
-            # On ROCm: use [2, ktiles-1, 0] which is the kernel's stable output format
-            # (start=0, end=ktiles-1, processes tiles 0..ktiles-2 via loop start_k < end_k).
-            # On CUDA: use [2, ktiles-1, -1] which triggers the kernel's full-range pass.
-            if _IS_ROCM:
-                init_val = [2, ktiles - 1, 0]
-            else:
-                init_val = [2, ktiles - 1, -1]
+            # One pair (end_incl=ktiles-1, start_excl=-1) covering all tiles.
             skip_list[0, :, :, :, 0:3] = torch.tensor(
-                init_val, dtype=torch.int16, device=device
+                [2, ktiles - 1, -1], dtype=torch.int16, device=device
             )
 
             # Note: Second buffer (skip_list[1]) is left uninitialized and will be populated
@@ -682,11 +647,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
             self._skip_list = self._init_skip_list(query, key, value, must_skip_list)
             # ditermines which part of self._skip_list to use for read_list and write_list
             self._phase = 0
-            # On ROCm, the CK kernel needs extra warmup passes after fresh initialization
-            # to converge to a stable skip list state within the user's 2 standard warmup calls
-            if _IS_ROCM:
-                self._rocm_needs_extra_warmup = True
-
             # update the last attributes to the current values
             self._last_seq_len = current_seq_len
             self._last_head_dim = current_head_dim
@@ -1024,20 +984,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
             assert isinstance(cfg, LiteAttentionRunConfig)
             threshold = cfg.threshold
 
-        # ROCm: for non-power-of-2 head dims without skip lists, pad to next power of 2
-        # to avoid uninitialized register contributions in the CK kernel's internal padding.
-        _orig_head_dim_pad = None
-        if _IS_ROCM and not self.enable_skipping and (head_dim & (head_dim - 1)) != 0:
-            _orig_head_dim_pad = head_dim
-            _next_pow2 = 1 << (head_dim - 1).bit_length()
-            _pad_size = _next_pow2 - head_dim
-            # Compute scale from original head_dim before padding
-            if softmax_scale is None:
-                softmax_scale = head_dim ** (-0.5)
-            query = F.pad(query, (0, _pad_size))
-            key = F.pad(key, (0, _pad_size))
-            value = F.pad(value, (0, _pad_size))
-
         output = flash_attn_func(
             q=query,
             k=key,
@@ -1053,103 +999,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
             phase=(self._phase == 1) if self.reverse_skip_list else False,
             use_int8=self.use_int8,
         )
-
-        # Unpad output if tensors were padded above
-        if _orig_head_dim_pad is not None:
-            if isinstance(output, tuple):
-                _out_padded, _lse = output
-                output = (_out_padded[..., :_orig_head_dim_pad], _lse)
-            else:
-                output = output[..., :_orig_head_dim_pad]
-
-        # ROCm post-processing: the CK kernel ignores must_do_list and has no minimum-tile
-        # guarantee when all tiles are skipped. Fix write_list here so the next pass reads
-        # the correct ranges.
-        if _IS_ROCM and self.enable_skipping and write_list is not None:
-            real_batch_size = query.shape[0]
-            if must_do_list_expanded is not None:
-                # Override write_list with the must_do ranges (kernel ignored them).
-                # must_do_list_expanded format: [num_vals, tile_start_0, tile_end_0_excl, ...]
-                # write_list format: [length, tile_end_0_excl, tile_start_0, ...]  (decreasing pairs)
-                n = int(must_do_list_expanded[0].item())
-                num_ranges = n // 2
-                write_list[:real_batch_size, :, :, 0] = n
-                for i in range(num_ranges):
-                    write_list[:real_batch_size, :, :, 2 * i + 1] = (
-                        must_do_list_expanded[2 * i + 2]
-                    )
-                    write_list[:real_batch_size, :, :, 2 * i + 2] = (
-                        must_do_list_expanded[2 * i + 1]
-                    )
-            else:
-                # Ensure at least 1 tile is recorded even when threshold skips everything.
-                # The kernel writes length=0 when all tiles are below threshold; enforce a
-                # single-tile range [2, 1, 0] so downstream assertions (e.g. test_skip_all)
-                # can always find a valid range.
-                all_zero = write_list[:real_batch_size, :, :, 0] == 0
-                if all_zero.any():
-                    write_list[:real_batch_size, :, :, 0] = torch.where(
-                        all_zero,
-                        write_list[:real_batch_size, :, :, 0].new_full((), 2),
-                        write_list[:real_batch_size, :, :, 0],
-                    )
-                    write_list[:real_batch_size, :, :, 1] = torch.where(
-                        all_zero,
-                        write_list[:real_batch_size, :, :, 1].new_full((), 1),
-                        write_list[:real_batch_size, :, :, 1],
-                    )
-                    write_list[:real_batch_size, :, :, 2] = torch.where(
-                        all_zero,
-                        write_list[:real_batch_size, :, :, 2].new_full((), 0),
-                        write_list[:real_batch_size, :, :, 2],
-                    )
-
-        # ROCm: if skip list was just initialized, run extra warmup passes to speed up
-        # convergence so the user's standard 2 warmup passes are sufficient for stability.
-        # Skip when must_do_list_expanded is set: the post-processed write_list already contains
-        # the correct must_do ranges and extra passes would overwrite them with the min-tile value.
-        if (
-            _IS_ROCM
-            and self.enable_skipping
-            and self._rocm_needs_extra_warmup
-            and must_do_list_expanded is None
-        ):
-            self._rocm_needs_extra_warmup = False
-            _extra_bs = query.shape[0]
-            for _ in range(2):
-                _e_read, _e_write = self._get_read_write_lists(query, key, value)
-                flash_attn_func(
-                    q=query,
-                    k=key,
-                    v=value,
-                    softmax_scale=softmax_scale,
-                    attn_read_list=_e_read,
-                    attn_must_do_list=None,
-                    attn_write_list=_e_write,
-                    thr=threshold,
-                    return_softmax_lse=False,
-                    reverse_skip_list=self.reverse_skip_list,
-                    phase=(self._phase == 1) if self.reverse_skip_list else False,
-                    use_int8=self.use_int8,
-                )
-                # Apply minimum-tile guarantee for each extra warmup pass
-                _e_zero = _e_write[:_extra_bs, :, :, 0] == 0
-                if _e_zero.any():
-                    _e_write[:_extra_bs, :, :, 0] = torch.where(
-                        _e_zero,
-                        _e_write[:_extra_bs, :, :, 0].new_full((), 2),
-                        _e_write[:_extra_bs, :, :, 0],
-                    )
-                    _e_write[:_extra_bs, :, :, 1] = torch.where(
-                        _e_zero,
-                        _e_write[:_extra_bs, :, :, 1].new_full((), 1),
-                        _e_write[:_extra_bs, :, :, 1],
-                    )
-                    _e_write[:_extra_bs, :, :, 2] = torch.where(
-                        _e_zero,
-                        _e_write[:_extra_bs, :, :, 2].new_full((), 0),
-                        _e_write[:_extra_bs, :, :, 2],
-                    )
 
         # Record calibration results and advance timestep
         if self.enable_skipping:
@@ -1167,20 +1016,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
                 skip_percentage=1.0 - self._last_percentage,
                 threshold=threshold,
             )
-
-        # ROCm: non-power-of-2 head dims have reduced bf16 LSE precision (the CK kernel pads
-        # to the next power of 2 internally, accumulating extra rounding error). Recompute
-        # LSE in fp32 when the caller requests it to maintain accuracy.
-        if _IS_ROCM and return_softmax_lse and (head_dim & (head_dim - 1)) != 0:
-            if isinstance(output, tuple):
-                _out_tensor, _ = output
-            else:
-                _out_tensor = output
-            _lse_scale = (
-                softmax_scale if softmax_scale is not None else head_dim ** (-0.5)
-            )
-            _lse_corrected = _rocm_lse_fp32_chunked(query, key, _lse_scale)
-            output = (_out_tensor, _lse_corrected)
 
         return output
 
@@ -1215,7 +1050,6 @@ class LiteAttention(nn.Module, ConfigurableModule):
         self.verbose_reinitialization = False
         self._last_percentage = 0.0
         self._last_num_heads = None
-        self._rocm_needs_extra_warmup = False
         self.restart_config()
 
     @property

--- a/hopper/lite_attention.py
+++ b/hopper/lite_attention.py
@@ -116,7 +116,6 @@ else:
 log = structlog.get_logger()
 
 
-
 @dataclass
 class LiteAttentionRunConfig(CalibratedRunConfig):
     """Runtime configuration for LiteAttention threshold."""
@@ -686,7 +685,7 @@ class LiteAttention(nn.Module, ConfigurableModule):
             self._last_use_int8 = self.use_int8
 
             if os.getenv("LITE_ATTENTION_VERBOSE", "FALSE") != "FALSE":
-                print(f"[Warning]: reinitialized skip list during the forward pass")
+                print("[Warning]: reinitialized skip list during the forward pass")
 
         # Alternate between the two skip list buffers
         if self._phase == 0:

--- a/hopper/tests/test_calibration_gpu.py
+++ b/hopper/tests/test_calibration_gpu.py
@@ -9,7 +9,6 @@ from lite_attention.calibrated_module import (
     ConfigList,
 )
 from lite_attention.lite_attention import (
-    LiteAttentionCalibConfig,
     LiteAttentionDisabledConfig,
     LiteAttentionRegistry,
     LiteAttentionRunConfig,

--- a/setup.py
+++ b/setup.py
@@ -462,14 +462,23 @@ def _rocm_toolchain_present():
 is_rocm = (torch.version.hip is not None) or _rocm_toolchain_present()
 
 if is_rocm:
-    print("\n\nBuilding for AMD ROCm...\n\n")
+    print("\n\nBuilding LiteAttention for AMD ROCm...\n\n")
 
-    os.environ["PYTORCH_ROCM_ARCH"] = "gfx942"
-    os.environ["TORCH_ROCM_ARCH_LIST"] = "gfx942"
+    os.environ["PYTORCH_ROCM_ARCH"] = os.environ.get("PYTORCH_ROCM_ARCH", "gfx942")
     os.environ["ROCM_ARCH"] = "gfx942"
 
-    # Head dims to generate for ROCm (same set as typical NVIDIA build for parity)
-    ROCM_HDIMS = [64, 96, 128, 192, 256]
+    # Head dims to build (all supported dims; use LITE_ATTENTION_DISABLE_HDIM* to trim)
+    ROCM_HDIMS = (
+        ([] if DISABLE_HDIM64 else [64])
+        + ([] if DISABLE_HDIM96 else [96])
+        + ([] if DISABLE_HDIM128 else [128])
+        + ([] if DISABLE_HDIM192 else [192])
+        + ([] if DISABLE_HDIM256 else [256])
+    )
+    # For dense kernels, generate each hdim with its own optdim to get exact tile sizes
+    ROCM_DENSE_HDIMS = ROCM_HDIMS
+    if not ROCM_HDIMS:
+        raise RuntimeError("ROCm build selected no head dimensions; enable at least one HDIM.")
     rocm_optdim = ",".join(str(h) for h in ROCM_HDIMS)
 
     # 1. Generate Kernels
@@ -496,95 +505,24 @@ if is_rocm:
             shutil.rmtree(str(generated_dir), ignore_errors=True)
     generated_dir.mkdir(parents=True, exist_ok=True)
 
-    # Build FWD filter: for each head dim, lite + baseline (qr nbias nmask) for fp16 and bf16
-    fwd_filter_parts = []
+    # Generate qr-lite pipeline kernels (skip-list attention).
+    # Per-hdim --optdim ensures each hdim gets optimal tile sizes (e.g. d128 uses bk0max=128).
+    # Generate kernel instantiations per-hdim, then regenerate the API file with all hdims.
+    print(f"Generating FWD lite kernels to {generated_dir} (head_dims={ROCM_HDIMS})...")
     for h in ROCM_HDIMS:
-        fwd_filter_parts.append(
-            f"*d{h}_fp16_batch*lite*|*d{h}_fp16_batch*qr*nbias*nmask*"
-            f"|*d{h}_bf16_batch*lite*|*d{h}_bf16_batch*qr*nbias*nmask*"
+        subprocess.run(
+            [sys.executable, str(generate_script),
+             "--api", "fwd", "--receipt", "600", "--optdim", str(h),
+             "--output_dir", str(generated_dir),
+             "--filter", f"*d{h}_bf16*_qr_lite*"],
+            check=True,
         )
-    fwd_filter = "|".join(fwd_filter_parts)
-
-    print(f"Generating FWD kernels to {generated_dir} (head_dims={ROCM_HDIMS})...")
+    # Regenerate the API dispatch file covering all hdims (generate.py overwrites it each run).
     subprocess.run(
-        [
-            sys.executable,
-            str(generate_script),
-            "--api",
-            "fwd",
-            "--optdim",
-            rocm_optdim,
-            "--output_dir",
-            str(generated_dir),
-            "--filter",
-            fwd_filter,
-        ],
-        check=True,
-    )
-
-    # Build BWD filter: for each head dim, fp16 and bf16
-    bwd_filter_parts = [f"*d{h}_fp16_batch*|*d{h}_bf16_batch*" for h in ROCM_HDIMS]
-    bwd_filter = "|".join(bwd_filter_parts)
-
-    print(f"Generating BWD kernels to {generated_dir} (head_dims={ROCM_HDIMS})...")
-    subprocess.run(
-        [
-            sys.executable,
-            str(generate_script),
-            "--api",
-            "bwd",
-            "--optdim",
-            rocm_optdim,
-            "--output_dir",
-            str(generated_dir),
-            "--filter",
-            bwd_filter,
-        ],
-        check=True,
-    )
-
-    # Generate APPENDKV kernels (receipt=2 = Flash attention integration: fp16/bf16 row-layout only)
-    print(
-        f"Generating FWD_APPENDKV kernels to {generated_dir} (head_dims={ROCM_HDIMS})..."
-    )
-    subprocess.run(
-        [
-            sys.executable,
-            str(generate_script),
-            "--api",
-            "fwd_appendkv",
-            "--optdim",
-            rocm_optdim,
-            "--output_dir",
-            str(generated_dir),
-            "--receipt",
-            "2",
-        ],
-        check=True,
-    )
-
-    # Generate SPLITKV kernels with sync-only (qr_vr/qr_vc) pipeline variants.
-    # receipt=2 limits to fp16/bf16/row/no-bias, and filter "@*qr_vr*|*qr_vc*" excludes
-    # qr_async variants (which reference BlockFmhaFwdSplitKVPipelineQRKSVSAsync that
-    # doesn't exist in the current CK headers). The '@' splits combine vs main filters.
-    print(
-        f"Generating FWD_SPLITKV kernels to {generated_dir} (head_dims={ROCM_HDIMS})..."
-    )
-    subprocess.run(
-        [
-            sys.executable,
-            str(generate_script),
-            "--api",
-            "fwd_splitkv",
-            "--optdim",
-            rocm_optdim,
-            "--output_dir",
-            str(generated_dir),
-            "--receipt",
-            "2",
-            "--filter",
-            "@*qr_vr*",
-        ],
+        [sys.executable, str(generate_script),
+         "--api", "fwd", "--receipt", "600", "--optdim", rocm_optdim,
+         "--output_dir", str(generated_dir),
+         "--filter", "*_qr_lite*"],
         check=True,
     )
 
@@ -609,59 +547,33 @@ if is_rocm:
             except Exception:
                 pass
 
-    # Copy flash_api.cpp -> flash_api.hip so we only maintain the .cpp (single source of truth)
-    flash_attn_ck_dir = repo_root / "csrc" / "flash_attn_ck"
-    shutil.copy(
-        flash_attn_ck_dir / "flash_api.cpp", flash_attn_ck_dir / "flash_api.hip"
-    )
-
     # 2. Collect Sources
-    def get_rocm_source(path_str):
-        path = Path(path_str)
-        if path.suffix == ".cpp":
-            hip_path = path.with_suffix(".hip")
-            if hip_path.exists():
-                return str(hip_path)
-        return str(path)
-
+    # Note: flash_attn_ck/ sources are NOT compiled here — they belong to the
+    # flash_attn._C extension (separate build). This extension only builds
+    # lite_attn_ck + generated CK kernels for lite_attention._C.
     sources = [
-        get_rocm_source(str(flash_attn_ck_dir / "flash_api.cpp")),
-        get_rocm_source(str(flash_attn_ck_dir / "flash_common.cpp")),
-        get_rocm_source(str(flash_attn_ck_dir / "mha_fwd.cpp")),
-        get_rocm_source(str(flash_attn_ck_dir / "mha_varlen_fwd.cpp")),
-        get_rocm_source(str(flash_attn_ck_dir / "mha_fwd_kvcache.cpp")),
+        str(repo_root / "csrc" / "lite_attn_ck" / "lite_attn.hip"),
         str(generated_dir / "fmha_fwd_api.hip"),
-        # mha_bwd is always registered in flash_api.hip without a DISABLE_BACKWARD guard
-        get_rocm_source(str(flash_attn_ck_dir / "mha_bwd.cpp")),
-        str(generated_dir / "fmha_bwd_api.hip"),
     ]
-
-    if not DISABLE_VARLEN:
-        sources.append(get_rocm_source(str(flash_attn_ck_dir / "mha_varlen_bwd.cpp")))
-
+    # Add generated kernel instantiations (skip API files and stale hipify outputs)
+    api_files = {"fmha_fwd_api.hip", "fmha_bwd_api.hip"}
     sources.extend(
-        str(p)
-        for p in generated_dir.glob("*.hip")
-        if p.name not in ["fmha_fwd_api.hip", "fmha_bwd_api.hip"]
-        and not p.name.endswith(
-            "_hip.hip"
-        )  # exclude hipify output files (stale from prior builds)
+        str(p) for p in generated_dir.glob("*.hip")
+        if p.name not in api_files and not p.name.endswith("_hip.hip")
     )
 
     # 3. Include Directories
     rocm_include_dirs = [
-        str(flash_attn_ck_dir),
         str(ck_dir / "include"),
         str(ck_dir / "library" / "include"),
         str(ck_dir / "example" / "ck_tile" / "01_fmha"),
         str(generated_dir),
     ]
 
-    # 4. Compiler Flags (ROCm/HIP uses hipcc which is Clang-based; -Wno-c++11-narrowing avoids
-    #    "float cannot be narrowed to index_t" when CK args use float threshold and compiler is strict)
+    # 4. Compiler Flags
+    rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH", "gfx942").split(";")[0]
     rocm_feature_args = (
-        []
-        + (["-DLITEATTENTION_DISABLE_BACKWARD"] if DISABLE_BACKWARD else [])
+        (["-DLITEATTENTION_DISABLE_BACKWARD"] if DISABLE_BACKWARD else [])
         + (["-DLITEATTENTION_DISABLE_PAGEDKV"] if DISABLE_PAGEDKV else [])
         + (["-DLITEATTENTION_DISABLE_SPLIT"] if DISABLE_SPLIT else [])
         + (["-DLITEATTENTION_DISABLE_APPENDKV"] if DISABLE_APPENDKV else [])
@@ -670,33 +582,21 @@ if is_rocm:
         + (["-DLITEATTENTION_DISABLE_PACKGQA"] if DISABLE_PACKGQA else [])
         + (["-DLITEATTENTION_DISABLE_FP16"] if DISABLE_FP16 else [])
         + (["-DLITEATTENTION_DISABLE_FP8"] if DISABLE_FP8 else [])
-        + (["-DLITEATTENTION_DISABLE_INT8"] if DISABLE_INT8 else [])
         + (["-DLITEATTENTION_DISABLE_VARLEN"] if DISABLE_VARLEN else [])
         + (["-DLITEATTENTION_DISABLE_CLUSTER"] if DISABLE_CLUSTER else [])
-        + (["-DLITEATTENTION_DISABLE_HDIM64"] if DISABLE_HDIM64 else [])
-        + (["-DLITEATTENTION_DISABLE_HDIM96"] if DISABLE_HDIM96 else [])
-        + (["-DLITEATTENTION_DISABLE_HDIM128"] if DISABLE_HDIM128 else [])
-        + (["-DLITEATTENTION_DISABLE_HDIM192"] if DISABLE_HDIM192 else [])
-        + (["-DLITEATTENTION_DISABLE_HDIM256"] if DISABLE_HDIM256 else [])
-        + (["-DCK_TILE_FMHA_FWD_FAST_EXP2=1"])
+        + ["-DCK_TILE_FMHA_FWD_FAST_EXP2=1"]
     )
+    compile_flags = [
+        "-O3",
+        "-std=c++17",
+        "-Wno-c++11-narrowing",
+        "-fgpu-flush-denormals-to-zero",
+        "-D__HIP_PLATFORM_AMD__=1",
+        f"-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={os.environ.get('CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT', 2)}",
+    ] + rocm_feature_args
     extra_compile_args = {
-        "cxx": [
-            "-O3",
-            "-std=c++17",
-            "-Wno-c++11-narrowing",
-            "-D__HIP_PLATFORM_AMD__=1",
-            "-DTORCH_EXTENSION_NAME=lite_attention._C",
-        ]
-        + rocm_feature_args,
-        "nvcc": [
-            "-O3",
-            "-std=c++17",
-            "-Wno-c++11-narrowing",
-            "-D__HIP_PLATFORM_AMD__=1",
-            "--offload-arch=gfx942",
-        ]
-        + rocm_feature_args,  # nvcc maps to hipcc in CUDAExtension when IS_HIP_EXTENSION is true
+        "cxx": compile_flags,
+        "nvcc": compile_flags + [f"--offload-arch={rocm_arch}"],
     }
 
     ext_modules.append(

--- a/setup.py
+++ b/setup.py
@@ -857,6 +857,7 @@ if not SKIP_CUDA_BUILD and not is_rocm:
         Path(this_dir) / SRC_DIR,
         Path(this_dir) / SRC_DIR / "_internal" / "cpp",
         cutlass_dir / "include",
+        Path(CUDA_HOME) / "include",
     ]
 
     ext_modules.append(

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,10 @@ from pathlib import Path
 
 import torch
 from packaging.version import Version, parse
-from setuptools import find_packages, setup
+from setuptools import setup
 from torch.utils.cpp_extension import (
     CUDA_HOME,
     BuildExtension,
-    CppExtension,
     CUDAExtension,
 )
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
@@ -478,7 +477,9 @@ if is_rocm:
     # For dense kernels, generate each hdim with its own optdim to get exact tile sizes
     ROCM_DENSE_HDIMS = ROCM_HDIMS
     if not ROCM_HDIMS:
-        raise RuntimeError("ROCm build selected no head dimensions; enable at least one HDIM.")
+        raise RuntimeError(
+            "ROCm build selected no head dimensions; enable at least one HDIM."
+        )
     rocm_optdim = ",".join(str(h) for h in ROCM_HDIMS)
 
     # 1. Generate Kernels
@@ -511,18 +512,38 @@ if is_rocm:
     print(f"Generating FWD lite kernels to {generated_dir} (head_dims={ROCM_HDIMS})...")
     for h in ROCM_HDIMS:
         subprocess.run(
-            [sys.executable, str(generate_script),
-             "--api", "fwd", "--receipt", "600", "--optdim", str(h),
-             "--output_dir", str(generated_dir),
-             "--filter", f"*d{h}_bf16*_qr_lite*"],
+            [
+                sys.executable,
+                str(generate_script),
+                "--api",
+                "fwd",
+                "--receipt",
+                "600",
+                "--optdim",
+                str(h),
+                "--output_dir",
+                str(generated_dir),
+                "--filter",
+                f"*d{h}_bf16*_qr_lite*",
+            ],
             check=True,
         )
     # Regenerate the API dispatch file covering all hdims (generate.py overwrites it each run).
     subprocess.run(
-        [sys.executable, str(generate_script),
-         "--api", "fwd", "--receipt", "600", "--optdim", rocm_optdim,
-         "--output_dir", str(generated_dir),
-         "--filter", "*_qr_lite*"],
+        [
+            sys.executable,
+            str(generate_script),
+            "--api",
+            "fwd",
+            "--receipt",
+            "600",
+            "--optdim",
+            rocm_optdim,
+            "--output_dir",
+            str(generated_dir),
+            "--filter",
+            "*_qr_lite*",
+        ],
         check=True,
     )
 
@@ -558,7 +579,8 @@ if is_rocm:
     # Add generated kernel instantiations (skip API files and stale hipify outputs)
     api_files = {"fmha_fwd_api.hip", "fmha_bwd_api.hip"}
     sources.extend(
-        str(p) for p in generated_dir.glob("*.hip")
+        str(p)
+        for p in generated_dir.glob("*.hip")
         if p.name not in api_files and not p.name.endswith("_hip.hip")
     )
 
@@ -839,7 +861,7 @@ if not SKIP_CUDA_BUILD and not is_rocm:
 
     ext_modules.append(
         CUDAExtension(
-            name=f"lite_attention._C",
+            name="lite_attention._C",
             sources=sources,
             extra_compile_args={
                 "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"]


### PR DESCRIPTION
This pull request refactors and simplifies the ROCm (AMD) backend support for LiteAttention, aligning it with the new Composable Kernel (CK) implementation. It removes legacy workarounds, updates the interface to use a new CK-based kernel, and clarifies the supported features and limitations in the documentation.

**ROCm backend refactor and CK kernel integration:**

- Introduced a new minimal HIP extension (`lite_attn.hip`) that wraps the CK `fmha_fwd` kernel, supporting only bf16, batch mode, and skip lists, and exposes this via a new `lite_attn_fwd` interface.
- Updated the Python interface to call the new `lite_attn_fwd` function for ROCm, removing legacy arguments and unused outputs.

**Simplification and removal of legacy ROCm workarounds:**

- Removed all logic related to padding non-power-of-2 head dimensions, post-processing of skip lists, and extra warmup passes for convergence, as these are no longer necessary with the CK kernel.
- Simplified skip list initialization to always use the CUDA-style format, since CK now expects this.

**Documentation and configuration updates:**

- Updated the `README.md` to accurately describe the supported features and limitations of the ROCm backend, including supported dtypes, head dimensions, and the removal of features not supported by CK.
- Updated tile size selection logic for ROCm to reflect CK’s fixed tile sizes.

**Dependency update:**

- Updated the `composable_kernel` submodule to a newer commit, ensuring compatibility with the new CK wrapper.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonmath-ai/liteattention/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
